### PR TITLE
Stop streams automatically once dropped and make path params more generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,9 @@ default-members = ["lighthouse-client"]
 resolver = "2"
 
 [workspace.package]
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 license = "MIT"
 
 [workspace.dependencies]
-lighthouse-protocol = { version = "^3.4.0", path = "lighthouse-protocol" }
+lighthouse-protocol = { version = "^3.4.1", path = "lighthouse-protocol" }

--- a/lighthouse-client/examples/admin_crud.rs
+++ b/lighthouse-client/examples/admin_crud.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use lighthouse_client::{protocol::Authentication, Error, Lighthouse, Result, TokioWebSocket, LIGHTHOUSE_URL};
 use tracing::{info, info_span, Instrument};
 
-async fn run(mut lh: Lighthouse<TokioWebSocket>) -> Result<()> {
+async fn run(lh: Lighthouse<TokioWebSocket>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
     async {

--- a/lighthouse-client/examples/admin_get_metrics.rs
+++ b/lighthouse-client/examples/admin_get_metrics.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use lighthouse_client::{protocol::Authentication, Lighthouse, Result, TokioWebSocket, LIGHTHOUSE_URL};
 use tracing::info;
 
-async fn run(mut lh: Lighthouse<TokioWebSocket>) -> Result<()> {
+async fn run(lh: Lighthouse<TokioWebSocket>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
     let metrics = lh.get_laser_metrics().await?.payload;

--- a/lighthouse-client/examples/admin_list_root.rs
+++ b/lighthouse-client/examples/admin_list_root.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use lighthouse_client::{protocol::Authentication, Lighthouse, Result, TokioWebSocket, LIGHTHOUSE_URL};
 use tracing::info;
 
-async fn run(mut lh: Lighthouse<TokioWebSocket>) -> Result<()> {
+async fn run(lh: Lighthouse<TokioWebSocket>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
     let tree = lh.list(&[]).await?.payload;

--- a/lighthouse-client/examples/admin_list_root.rs
+++ b/lighthouse-client/examples/admin_list_root.rs
@@ -1,11 +1,11 @@
 use clap::Parser;
-use lighthouse_client::{protocol::Authentication, Lighthouse, Result, TokioWebSocket, LIGHTHOUSE_URL};
+use lighthouse_client::{protocol::Authentication, root, Lighthouse, Result, TokioWebSocket, LIGHTHOUSE_URL};
 use tracing::info;
 
 async fn run(lh: Lighthouse<TokioWebSocket>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
-    let tree = lh.list(&[]).await?.payload;
+    let tree = lh.list(root![]).await?.payload;
     info!("Got {}", tree);
 
     Ok(())

--- a/lighthouse-client/examples/black.rs
+++ b/lighthouse-client/examples/black.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use lighthouse_client::{protocol::{Authentication, Color, Frame}, Lighthouse, Result, TokioWebSocket, LIGHTHOUSE_URL};
 use tracing::info;
 
-async fn run(mut lh: Lighthouse<TokioWebSocket>) -> Result<()> {
+async fn run(lh: Lighthouse<TokioWebSocket>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
     lh.put_model(Frame::fill(Color::BLACK)).await?;

--- a/lighthouse-client/examples/disco.rs
+++ b/lighthouse-client/examples/disco.rs
@@ -4,7 +4,7 @@ use tracing::info;
 use tokio::time;
 use std::time::Duration;
 
-async fn run(mut lh: Lighthouse<TokioWebSocket>) -> Result<()> {
+async fn run(lh: Lighthouse<TokioWebSocket>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
     loop {

--- a/lighthouse-client/examples/input_events.rs
+++ b/lighthouse-client/examples/input_events.rs
@@ -4,7 +4,7 @@ use lighthouse_client::{protocol::Authentication, Lighthouse, Result, TokioWebSo
 use lighthouse_protocol::Model;
 use tracing::info;
 
-async fn run(mut lh: Lighthouse<TokioWebSocket>) -> Result<()> {
+async fn run(lh: Lighthouse<TokioWebSocket>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
     // Stream input events

--- a/lighthouse-client/examples/snake.rs
+++ b/lighthouse-client/examples/snake.rs
@@ -124,7 +124,7 @@ impl State {
     }
 }
 
-async fn run_updater(mut lh: Lighthouse<TokioWebSocket>, shared_state: Arc<Mutex<State>>) -> Result<()> {
+async fn run_updater(lh: Lighthouse<TokioWebSocket>, shared_state: Arc<Mutex<State>>) -> Result<()> {
     loop {
         // Update the snake and render it
         let frame = {
@@ -190,7 +190,7 @@ async fn main() -> Result<()> {
     let auth = Authentication::new(&args.username, &args.token);
     let state = Arc::new(Mutex::new(State::new()));
 
-    let mut lh = Lighthouse::connect_with_tokio_to(&args.url, auth).await?;
+    let lh = Lighthouse::connect_with_tokio_to(&args.url, auth).await?;
     info!("Connected to the Lighthouse server");
 
     let stream = lh.stream_model().await?;

--- a/lighthouse-client/examples/stress_test.rs
+++ b/lighthouse-client/examples/stress_test.rs
@@ -5,7 +5,7 @@ use lighthouse_client::{protocol::{Authentication, Frame}, Lighthouse, Result, T
 use tokio::time::{self, Instant};
 use tracing::info;
 
-async fn run(mut lh: Lighthouse<TokioWebSocket>, delay_ms: Option<u64>) -> Result<()> {
+async fn run(lh: Lighthouse<TokioWebSocket>, delay_ms: Option<u64>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
     let mut last_second = Instant::now();

--- a/lighthouse-client/src/lib.rs
+++ b/lighthouse-client/src/lib.rs
@@ -13,3 +13,11 @@ pub use lighthouse::*;
 pub use spawn::*;
 
 pub use lighthouse_protocol as protocol;
+
+/// Small convenience macro that expresses the root path.
+#[macro_export]
+macro_rules! root {
+    () => {
+        &[] as &[&str]
+    };
+}

--- a/lighthouse-client/src/lighthouse.rs
+++ b/lighthouse-client/src/lighthouse.rs
@@ -120,81 +120,81 @@ impl<S> Lighthouse<S>
     }
 
     /// Replaces the user's lighthouse model with the given frame.
-    pub async fn put_model(&mut self, frame: Frame) -> Result<ServerMessage<()>> {
+    pub async fn put_model(&self, frame: Frame) -> Result<ServerMessage<()>> {
         let username = self.authentication.username.clone();
         self.put(&["user", username.as_str(), "model"], Model::Frame(frame)).await
     }
 
     /// Requests a stream of events (including key/controller events) for the user's lighthouse model.
-    pub async fn stream_model(&mut self) -> Result<impl Stream<Item = Result<ServerMessage<Model>>>> {
+    pub async fn stream_model(&self) -> Result<impl Stream<Item = Result<ServerMessage<Model>>>> {
         let username = self.authentication.username.clone();
         self.stream(&["user", username.as_str(), "model"], ()).await
     }
 
     /// Fetches lamp server metrics.
-    pub async fn get_laser_metrics(&mut self) -> Result<ServerMessage<LaserMetrics>> {
+    pub async fn get_laser_metrics(&self) -> Result<ServerMessage<LaserMetrics>> {
         self.get(&["metrics", "laser"]).await
     }
 
     /// Combines PUT and CREATE. Requires CREATE and WRITE permission.
-    pub async fn post<P>(&mut self, path: &[&str], payload: P) -> Result<ServerMessage<()>>
+    pub async fn post<P>(&self, path: &[&str], payload: P) -> Result<ServerMessage<()>>
     where
         P: Serialize {
         self.perform(&Verb::Post, path, payload).await
     }
 
     /// Updates the resource at the given path with the given payload. Requires WRITE permission.
-    pub async fn put<P>(&mut self, path: &[&str], payload: P) -> Result<ServerMessage<()>>
+    pub async fn put<P>(&self, path: &[&str], payload: P) -> Result<ServerMessage<()>>
     where
         P: Serialize {
         self.perform(&Verb::Put, path, payload).await
     }
 
     /// Creates a resource at the given path. Requires CREATE permission.
-    pub async fn create(&mut self, path: &[&str]) -> Result<ServerMessage<()>> {
+    pub async fn create(&self, path: &[&str]) -> Result<ServerMessage<()>> {
         self.perform(&Verb::Create, path, ()).await
     }
 
     /// Deletes a resource at the given path. Requires DELETE permission.
-    pub async fn delete(&mut self, path: &[&str]) -> Result<ServerMessage<()>> {
+    pub async fn delete(&self, path: &[&str]) -> Result<ServerMessage<()>> {
         self.perform(&Verb::Delete, path, ()).await
     }
 
     /// Creates a directory at the given path. Requires CREATE permission.
-    pub async fn mkdir(&mut self, path: &[&str]) -> Result<ServerMessage<()>> {
+    pub async fn mkdir(&self, path: &[&str]) -> Result<ServerMessage<()>> {
         self.perform(&Verb::Mkdir, path, ()).await
     }
 
     /// Lists the directory tree at the given path. Requires READ permission.
-    pub async fn list(&mut self, path: &[&str]) -> Result<ServerMessage<DirectoryTree>> {
+    pub async fn list(&self, path: &[&str]) -> Result<ServerMessage<DirectoryTree>> {
         self.perform(&Verb::List, path, ()).await
     }
 
     /// Gets the resource at the given path. Requires READ permission.
-    pub async fn get<R>(&mut self, path: &[&str]) -> Result<ServerMessage<R>>
+    pub async fn get<R>(&self, path: &[&str]) -> Result<ServerMessage<R>>
     where
         R: for<'de> Deserialize<'de> {
         self.perform(&Verb::Get, path, ()).await
     }
 
     /// Links the given source to the given destination path.
-    pub async fn link(&mut self, src_path: &[&str], dest_path: &[&str]) -> Result<ServerMessage<()>> {
+    pub async fn link(&self, src_path: &[&str], dest_path: &[&str]) -> Result<ServerMessage<()>> {
         self.perform(&Verb::Link, dest_path, src_path).await
     }
 
     /// Unlinks the given source from the given destination path.
-    pub async fn unlink(&mut self, src_path: &[&str], dest_path: &[&str]) -> Result<ServerMessage<()>> {
+    pub async fn unlink(&self, src_path: &[&str], dest_path: &[&str]) -> Result<ServerMessage<()>> {
         self.perform(&Verb::Unlink, dest_path, src_path).await
     }
 
     /// Stops the given stream.
-    pub async fn stop(&mut self, path: &[&str]) -> Result<ServerMessage<()>> {
+    pub async fn stop(&self, path: &[&str]) -> Result<ServerMessage<()>> {
         self.perform(&Verb::Stop, path, ()).await
     }
 
     /// Performs a single request to the given path with the given payload.
     #[tracing::instrument(skip(self, payload))]
-    pub async fn perform<P, R>(&mut self, verb: &Verb, path: &[&str], payload: P) -> Result<ServerMessage<R>>
+    pub async fn perform<P, R>(&self, verb: &Verb, path: &[&str], payload: P) -> Result<ServerMessage<R>>
     where
         P: Serialize,
         R: for<'de> Deserialize<'de> {
@@ -206,7 +206,7 @@ impl<S> Lighthouse<S>
     
     /// Performs a STREAM request to the given path with the given payload.
     #[tracing::instrument(skip(self, payload))]
-    pub async fn stream<P, R>(&mut self, path: &[&str], payload: P) -> Result<impl Stream<Item = Result<ServerMessage<R>>>>
+    pub async fn stream<P, R>(&self, path: &[&str], payload: P) -> Result<impl Stream<Item = Result<ServerMessage<R>>>>
     where
         P: Serialize,
         R: for<'de> Deserialize<'de> {
@@ -217,7 +217,7 @@ impl<S> Lighthouse<S>
     }
 
     /// Sends a request to the given path with the given payload.
-    async fn send_request<P>(&mut self, verb: &Verb, path: &[&str], payload: P) -> Result<i32>
+    async fn send_request<P>(&self, verb: &Verb, path: &[&str], payload: P) -> Result<i32>
     where
         P: Serialize {
         let path = path.into_iter().map(|s| s.to_string()).collect();
@@ -235,7 +235,7 @@ impl<S> Lighthouse<S>
     }
 
     /// Sends a generic message to the lighthouse.
-    async fn send_message<P>(&mut self, message: &ClientMessage<P>) -> Result<()>
+    async fn send_message<P>(&self, message: &ClientMessage<P>) -> Result<()>
     where
         P: Serialize {
         self.send_raw(rmp_serde::to_vec_named(message)?).await
@@ -291,7 +291,7 @@ impl<S> Lighthouse<S>
     }
 
     /// Sends raw bytes to the lighthouse via the WebSocket connection.
-    async fn send_raw(&mut self, bytes: impl Into<Vec<u8>> + Debug) -> Result<()> {
+    async fn send_raw(&self, bytes: impl Into<Vec<u8>> + Debug) -> Result<()> {
         Ok(self.ws_sink.lock().await.send(Message::Binary(bytes.into())).await?)
     }
 

--- a/lighthouse-client/src/lighthouse.rs
+++ b/lighthouse-client/src/lighthouse.rs
@@ -303,7 +303,7 @@ impl<S> Lighthouse<S>
     /// Closes the WebSocket connection gracefully with a close message. While
     /// the server will usually also handle abruptly closed connections
     /// properly, it is recommended to always close the [``Lighthouse``].
-    pub async fn close(&mut self) -> Result<()> {
-        Ok(self.ws_sink.close().await?)
+    pub async fn close(&self) -> Result<()> {
+        Ok(self.ws_sink.lock().await.close().await?)
     }
 }

--- a/lighthouse-client/src/lighthouse.rs
+++ b/lighthouse-client/src/lighthouse.rs
@@ -9,7 +9,6 @@ use tracing::{warn, error, debug, info};
 use crate::{Check, Error, Result, Spawner};
 
 /// A connection to the lighthouse server for sending requests and receiving events.
-#[derive(Clone)]
 pub struct Lighthouse<S> {
     /// The sink-part of the WebSocket connection.
     ws_sink: Arc<Mutex<SplitSink<S, Message>>>,
@@ -305,5 +304,20 @@ impl<S> Lighthouse<S>
     /// properly, it is recommended to always close the [``Lighthouse``].
     pub async fn close(&self) -> Result<()> {
         Ok(self.ws_sink.lock().await.close().await?)
+    }
+}
+
+// For some reason `#[derive(Clone)]` adds the trait bound `S: Clone`, despite
+// not actually being needed since the WebSocket sink is already wrapped in an
+// `Arc`, therefore we implement `Clone` manually.
+
+impl<S> Clone for Lighthouse<S> {
+    fn clone(&self) -> Self {
+        Self {
+            ws_sink: self.ws_sink.clone(),
+            slots: self.slots.clone(),
+            authentication: self.authentication.clone(),
+            request_id: self.request_id.clone(),
+        }
     }
 }


### PR DESCRIPTION
This adds a guard to streams that automatically issues a `STOP` once dropped.

Implementing this required a rather major change to the implementation, namely wrapping the internal state into `Arc`/`Mutex`/atomics to make `Lighthouse` cloneable, since the stop guard requires keeping a reference to the `Lighthouse` alive (dynamically). This refactoring is implemented in the [`lh-shared-state`](https://github.com/ProjectLighthouseCAU/lighthouse-rust/tree/lh-shared-state) branch, which this PR is based upon.