### PR TITLE
Make path parameters more generic

### DIFF
--- a/lighthouse-client/examples/admin_list_root.rs
+++ b/lighthouse-client/examples/admin_list_root.rs
@@ -5,7 +5,7 @@ use tracing::info;
 async fn run(mut lh: Lighthouse<TokioWebSocket>) -> Result<()> {
     info!("Connected to the Lighthouse server");
 
-    let tree = lh.list(&[]).await?.payload;
+    let tree = lh.list([""; 0]).await?.payload;
     info!("Got {}", tree);
 
     Ok(())


### PR DESCRIPTION
Instead of taking `&[&str]`, this refactors most path parameters to take `impl Iterator<Item = impl AsRef<str>>`. This should make it possible to pass owned containers (e.g. `Vec`s or arrays), including those containing owned `String`s.

While this seems to be [the suggested approach](https://stackoverflow.com/questions/67810785/proper-signature-for-a-function-accepting-an-iterator-of-strings) for passing strings generically, it significantly impairs readability and introduces some ambiguities when passing empty paths (previously `&[]` would have been accepted, which is now ambiguous due to the generic `impl AsRef<str>`).

Draft PR for now until we figure out a more acceptable tradeoff.