### PR TITLE
Fix stream error handling

### DIFF
--- a/lighthouse-client/src/lighthouse.rs
+++ b/lighthouse-client/src/lighthouse.rs
@@ -244,7 +244,7 @@ impl<S> Lighthouse<S>
         let path: Vec<String> = path.into_iter().map(|s| s.as_ref().to_string()).collect();
         self.send_request(request_id, &Verb::Stream, &path, payload).await?;
         let stream = self.receive_streaming(request_id).await?;
-        Ok(stream.guard({
+        Ok(stream.map(|m| Ok(m?.check()?.decode_payload()?)).guard({
             // Stop the stream on drop
             let this = (*self).clone();
             move || {


### PR DESCRIPTION
We need to check the response before decoding the payload to avoid trying to parse the error message into the concrete payload type.